### PR TITLE
Override puts method to use Trump's nicknames for other candidates

### DIFF
--- a/lib/trumpify.rb
+++ b/lib/trumpify.rb
@@ -11,6 +11,16 @@ module Trumpify
       super unless m = method_name.match(/make_(.*)_great_again/)
       send(m.captures[0], *args, &block)
     end
+
+    alias_method :old_puts, :puts
+
+    def puts(str)
+      str.gsub! /Hillary Clinton/, 'Crooked Hillary'
+      str.gsub! /Bernie Sanders/, 'Crazy Bernie'
+      str.gsub! /Ted Cruz/, "Lyin' Ted"
+      str.gsub! /Marco Rubio/, 'Little Marco'
+      old_puts str
+    end
   end
 end
 

--- a/test/trumpy_test.rb
+++ b/test/trumpy_test.rb
@@ -27,4 +27,20 @@ class TrumpifyTest < Minitest::Test
     o = Object.make_new_great_again
     assert_kind_of Object, o
   end
+
+  def test_it_corrects_hillary_clinton_supporters
+    assert_output(/Crooked Hillary for President!/) { puts 'Hillary Clinton for President!' }
+  end
+
+  def test_it_corrects_bernie_sanders_supporters
+    assert_output(/Crazy Bernie for President!/) { puts 'Bernie Sanders for President!' }
+  end
+
+  def test_it_corrects_ted_cruz_supporters
+    assert_output(/Lyin' Ted for President!/) { puts 'Ted Cruz for President!' }
+  end
+
+  def test_it_corrects_marco_rubio_supporters
+    assert_output(/Little Marco for President!/) { puts 'Marco Rubio for President!' }
+  end
 end


### PR DESCRIPTION
Trump has a penchant for giving other candidates [cute little nicknames](http://archive.is/2016.08.24-015831/http://abcnews.go.com/Politics/crooked-hillary-marco-donald-trumps-nicknames/story?id=39035114). This feature will automatically replace those candidates' names with their corresponding nicknames.
